### PR TITLE
Tidy render warnings

### DIFF
--- a/src/Component/Weather.js
+++ b/src/Component/Weather.js
@@ -47,15 +47,15 @@ export default function Weather() {
                     </thead>
                     <tbody>
                        
-                            {repo.map((repos) => (
-                               <> <tr>
+                            {repo.map((repos, i) => (
+                               <tr key={i}>
                              <td>{repos.timepoint}</td>
                                 <td>{repos.cloudcover}</td>
                                 <td>{repos.prec_type}</td>
                                 <td>{repos.temp2m}</td>
                                 <td>{repos.wind10m.speed}</td>
                                 <td>{repos.wind10m.direction}</td>
-                                </tr></>
+                                </tr>
                             ))
                             }
 


### PR DESCRIPTION
This removes the fragment element ( `<>` ) which we don't need because the `<tr>` is wrapping everything. It also adds `key={i}` which gets the `i` from the `map` array method. You can google why React wants unique keys on children of arrays like this, I'm afraid I've forgotten the exact reason!